### PR TITLE
Prepping 1.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [1.1.1] - 2017-05-24
+## [1.1.2] - 2017-05-24
+
+### Fixed
+
+- Replaced corrupt `.gem` upload to RubyGems
+
+## [1.1.1] - 2017-05-24 - [YANKED]
 
 ### Added
 
@@ -56,7 +62,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Initial Release
 
-[Unreleased]: https://github.com/civisanalytics/tableau_api/compare/v1.1.1...HEAD
+[Unreleased]: https://github.com/civisanalytics/tableau_api/compare/v1.1.2...HEAD
+[1.1.2]: https://github.com/civisanalytics/tableau_api/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/civisanalytics/tableau_api/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/civisanalytics/tableau_api/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/civisanalytics/tableau_api/tree/v1.0.0

--- a/lib/tableau_api/version.rb
+++ b/lib/tableau_api/version.rb
@@ -1,3 +1,3 @@
 module TableauApi
-  VERSION = '1.1.1'.freeze
+  VERSION = '1.1.2'.freeze
 end


### PR DESCRIPTION
`rake build` somehow produced a corrupt `.gem`. I yanked 1.1.1 from RubyGems. This updates the version to 1.1.2 for a new upload and updates the CHANGELOG to reflect the bump and yank.