### PR TITLE
Update rubyzip dependency

### DIFF
--- a/tableau_api.gemspec
+++ b/tableau_api.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'httparty', '~> 0.13'
   spec.add_dependency 'builder', '~> 3.2'
   spec.add_dependency 'multipart-post', '~> 2.0'
-  spec.add_dependency 'rubyzip', '~> 1.0'
+  spec.add_dependency 'rubyzip', '~> 2.0'
 
   spec.add_development_dependency 'rake', '~> 11.0'
   spec.add_development_dependency 'rspec', '~> 3.6'


### PR DESCRIPTION
Minimal update to make the gem use `rubyzip` v2 which most other gems would depend on.