### PR TITLE
Depend upon Docker ruby version that matches gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## upcoming
+
+### Changed
+
+- Specify major version number of ruby in Docker testing command in README
+
+
 ## [4.0.0] - 2020-11-30
 
 ### Changed/Fixed

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 ### Docker
 
 ```
-docker run -it -d -v $(pwd):/src ruby /bin/bash
+docker run -it -d -v $(pwd):/src ruby:2 /bin/bash
 docker exec -it CONTAINER_ID /bin/bash -c "cd /src && bundle && rake"
 ```
 


### PR DESCRIPTION
`ruby:latest` now resolves to ruby v3+ so this updates the README for the correct Docker command to run for testing.