### PR TITLE
Add method to get groups for a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## upcoming
+
+### Added
+
+- Add `get_groups` method for users: https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref.htm#get_groups_for_a_user
+
+### Changed
+
+- Updated to API version 3.7
+
+
 ## [4.0.0] - 2020-11-30
 
 ### Changed/Fixed

--- a/lib/tableau_api/connection.rb
+++ b/lib/tableau_api/connection.rb
@@ -1,6 +1,6 @@
 module TableauApi
   class Connection
-    API_VERSION = '3.1'.freeze
+    API_VERSION = '3.7'.freeze
 
     include HTTParty
     headers 'User-Agent' => "tableau_api/#{::TableauApi::VERSION} Ruby/#{RUBY_VERSION}"

--- a/lib/tableau_api/resources/users.rb
+++ b/lib/tableau_api/resources/users.rb
@@ -24,6 +24,11 @@ module TableauApi
         res['tsResponse']['user'] if res.code == 201
       end
 
+      def get_groups(user_id:)
+        url = "sites/#{@client.auth.site_id}/users/#{user_id}/groups"
+        @client.connection.api_get_collection(url, 'groups.group')
+      end
+
       def list
         url = "sites/#{@client.auth.site_id}/users"
         @client.connection.api_get_collection(url, 'users.user')

--- a/spec/resources/users_spec.rb
+++ b/spec/resources/users_spec.rb
@@ -22,6 +22,22 @@ describe TableauApi::Resources::Users, vcr: { cassette_name: 'users' } do
     end
   end
 
+  describe '#get_groups' do
+    # https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref.htm#get_groups_for_a_user
+    it 'can retrieve groups for a specific user' do
+      sleep(15) if VCR.current_cassette.recording?
+      user = client.users.list.find do |u|
+        u['name'] == 'test'
+      end
+      group = client.groups.create(name: 'get_groups test')
+      expect(client.groups.add_user(group_id: group['id'], user_id: user['id'])).to be true
+
+      groups = client.users.get_groups(user_id: user['id'])
+      group_ids = groups.map { |group| group['id'] }
+      expect(group_ids).to include?(groups['id'])
+    end
+  end
+
   describe '#list' do
     # http://onlinehelp.tableau.com/v9.0/api/rest_api/en-us/help.htm#REST/rest_api_ref.htm#Get_Users_on_Site
     it 'can list users in a site' do


### PR DESCRIPTION
Add `get_groups` method to [get groups for a user](https://help.tableau.com/current/api/rest_api/en-us/REST/rest_api_ref.htm#get_groups_for_a_user).

The API needed to be bumped to v3.7 to support this.

Things that should probably be done before merging:

- update VCR fixtures (I don't have a server setup to run the specs against at the moment)
- determine if there are any breaking issues changing from API version 3.1 to 3.7 and add them to the CHANGELOG (I didn't see anything from a quick skim)
