### PR TITLE
Version fix and arg passing correction on options

### DIFF
--- a/lib/tableau_api.rb
+++ b/lib/tableau_api.rb
@@ -20,7 +20,7 @@ require 'tableau_api/resources/jobs'
 module TableauApi
   class << self
     def new(options = {})
-      Client.new(options)
+      Client.new(**options)
     end
   end
 end

--- a/tableau_api.gemspec
+++ b/tableau_api.gemspec
@@ -19,12 +19,12 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '~> 2.1'
+  spec.required_ruby_version = '>= 2.1'
 
   spec.add_dependency 'httparty', '~> 0.13'
   spec.add_dependency 'builder', '~> 3.2'
   spec.add_dependency 'multipart-post', '~> 2.0'
-  spec.add_dependency 'rubyzip', '~> 1.0'
+  spec.add_dependency 'rubyzip', '>= 1.0'
 
   spec.add_development_dependency 'rake', '~> 11.0'
   spec.add_development_dependency 'rspec', '~> 3.6'


### PR DESCRIPTION
I have faced a conflict few days ago with using the API wrapper.

So, I used `>=` for rubyzip library and also the ruby version to allow me use the library in ruby `3.1.0`. I run the tests on the environment but maybe you need to rerun the tests on `2.1.0` and `2.4.10` to make sure if it is not breaking anything.

Thanks